### PR TITLE
bench: provide mg::aio bench results

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 		# This is needed at least for correct macro handling. Default behaviour won't
 		# expand __VA_ARGS__ correctly.
 		/Zc:preprocessor
-		/Wall /WX /wd4266 /wd4324 /wd4355 /wd4365 /wd4458 /wd4514 /wd4548 /wd4625 /wd4626
+		/WX /wd4266 /wd4324 /wd4355 /wd4365 /wd4458 /wd4514 /wd4548 /wd4625 /wd4626
 		/wd4668 /wd4710 /wd4820 /wd5026 /wd5027 /wd5039 /wd5045 /wd5105 /wd5219 /wd26439
 		/wd26800
 		# It ignores 'break' and 'fallthrough' done via a macro which makes it annoying

--- a/bench/io/BenchIOHelp.cpp
+++ b/bench/io/BenchIOHelp.cpp
@@ -107,6 +107,9 @@ R"--(A command line utility to benchmark network code performance.
         beginning, waits one response, sends next message, waits next response, sends
         message, etc. So each connection always has 10 messages in fly. Default is 1.
 
+    -message_target_count - How many messages to send in total before the client is
+        gracefully terminated. Default = infinity, run forever.
+
     -target_host - Host where the server listens. Default is localhost.
 
     -disconnect_period - Disconnect a client each 'disconnect_period' messages. That

--- a/bench/io/BenchIOTools.cpp
+++ b/bench/io/BenchIOTools.cpp
@@ -38,7 +38,7 @@ namespace io {
 
 	static constexpr int theSampleInterval = 100;
 	static constexpr int theSampleDuration = 2000;
-	static constexpr int theMomentInterval = 1000;
+	static constexpr int theMomentInterval = 100;
 	static constexpr int theBucketCount = theSampleDuration / theSampleInterval;
 	static constexpr int theMagicNumber = 0xdeadbeef;
 
@@ -199,7 +199,7 @@ namespace io {
 			double latency = myLatencyAvg.Get();
 			myLatencyAvg.GoToNextBucket();
 
-			uint64_t speed = mySpeed.Get() * 1000 / theMomentInterval;
+			uint64_t speed = mySpeed.Get() * 1000 / theSampleDuration;
 			mySpeed.GoToNextBucket();
 
 			if (myMode == REPORT_MODE_ONLINE)

--- a/bench/io/CMakeLists.txt
+++ b/bench/io/CMakeLists.txt
@@ -22,7 +22,7 @@ else()
 endif()
 add_executable(bench_io ${bench_io_src})
 target_compile_definitions(bench_io PRIVATE ${BOOST_MACRO})
-target_include_directories(bench_io PUBLIC ${bench_io_include_dirs})
+target_include_directories(bench_io SYSTEM PUBLIC ${bench_io_include_dirs})
 
 target_link_libraries(bench_io
 	mgaio

--- a/bench/io/README.md
+++ b/bench/io/README.md
@@ -1,0 +1,31 @@
+# Serverbox AIO
+
+The tests show `mg::aio` things perform. Specifically - `mg::aio::IOCore` and `mg::aio::TCPSocketIFace`.
+
+To make it more interesting, the benchmarks compare those guys with `boost::asio` - `context`, `strand`, `ip::tcp::socket`.
+
+The assumption was that one of the major boost problems would be that it heavily uses callbacks. Specifically, it requires to pass them for each read and write and any other network operation. That implies intense usage of the heap, to allocate and keep all those callbacks until the operations are done.
+
+Another point, without any proofs, is that this boost `asio::context` most likely has a different scheduling algorithm than Serverbox. Supposedly less efficient when it comes to scaling horizontally over many threads. In particular, Serverbox' scheduling algo is TaskScheduler, located in `mg/sch` which implements something what could be called "Perfectly Fail Scheduling". Its main goal is to balance work across multiple threads evenly and in batches.
+
+The results of those comparisons follow below.
+
+## Results
+
+The numbers depend very much on the hardware and test scenario. They are all available in the `results/` folder right here.
+
+As expected, on all platforms in all scenarios Serverbox is faster than Boost in x1.1 - x5 times. Average seems to be around x1.5. The only exceptions are some runs on Windows in `weak_many_cores`. About those below.
+
+Why Serverbox is so much faster, especially on large messages, could be explained by the assumptions made above in the intro:
+- Serverbox doesn't require callbacks. At least not on the transport layer, where there is just a byte stream. Each byte is a "request". Instead, Serverbox allows to overload some virtual functions to listen for IO events. Indeed, even in Boost those callbacks are usually the same on each invocation. In Serverbox they are just regular functions provided once.
+- Serverbox uses Perfectly Fail Scheduling strategy, which could explain why it scales so well. Even in the unfriendly Windows environment it managed to beat Boost on the massively parallel scenario.
+
+Now why Windows was faster in 2 runs? When thread count was 10. But was slower on 1 thread and on 20 threads - how? The possible explanation is that on Windows boost doesn't seem to have any manual scheduling. Instead, (at the time of writing) it was using `GetQueuedCompletionStatus()` in each worker thread. This function returns one IO event from the kernel at a time, and is safe to call in multiple threads. In this setup the kernel or the Windows' built-in library seem to be doing the scheduling on their own. The Boost code just calls this in each worker in a loop.
+
+However this function has no batching. It returns only one IO event at a time. If this is a syscall, then it is clear why the performance is like this. On the single thread case Serverbox wins because of batching - it uses `GetQueuedCompletionStatusEx()` to fetch many events at once. When thread count goes up, Boost becomes a bit faster, because the absence of batching is covered by just doing this syscall in more threads in parallel. But when thread count goes beyond a certain limit, Boost seems to loose probably because that number of syscalls is just too much overhead even in parallel.
+
+Another explanation is that whatever `GetQueuedCompletionStatus()` uses internally as a queue, is just too different from Serverbox queues, and has different limitations.
+
+The syscall explanation seems the most plausible.
+
+The tests can be reproduced by anybody anywhere. When boost is not available, it won't be built and the benchmarks will simply give some absolute numbers how Serverbox network performs. When boost is available, it is built and used in the benches too.

--- a/bench/io/config-strong.json
+++ b/bench/io/config-strong.json
@@ -1,0 +1,54 @@
+{
+	"os": "Operating system name and version",
+	"cpu": "Processor details",
+	"comment-server": "Server: -thread_count 5 -mode server",
+	"versions": {
+		"aio": {
+			"name": "mg::aio network",
+			"short_name": "mg::aio",
+			"exe": "bench_io",
+			"cmd": "-backend mg_aio -report summary -mode client"
+		},
+		"boost": {
+			"name": "boost::asio network",
+			"short_name": "boost::asio",
+			"exe": "bench_io",
+			"cmd": "-backend boost_asio -report summary -mode client",
+			"cond": "-test 1 -backend boost_asio"
+		}
+	},
+	"main_version": "aio",
+	"metric_key": "Message/sec(med)",
+	"metric_name": "messages per second",
+	"precision": 0.01,
+	"scenarios": [
+		{
+			"name": "Basic",
+			"cmd": "-thread_count 5 -connect_count_per_port 100 -message_payload_size 128 -message_int_count 5 -message_target_count 5000000",
+			"count": 5
+		},
+		{
+			"name": "Single thread",
+			"cmd": "-thread_count 1 -connect_count_per_port 100 -message_payload_size 128 -message_int_count 5 -message_target_count 2000000",
+			"count": 5
+		},
+		{
+			"name": "5 threads 100kb messages",
+			"cmd": "-thread_count 5 -connect_count_per_port 200 -message_payload_size 102400",
+			"count": 5,
+			"versions": {
+				"aio": {
+					"cmd": "-message_target_count 800000"
+				},
+				"boost": {
+					"cmd": "-message_target_count 500000"
+				}
+			}
+		},
+		{
+			"name": "Parallel messages",
+			"cmd": "-thread_count 5 -connect_count_per_port 100 -message_payload_size 128 -message_parallel_count 5 -message_target_count 20000000",
+			"count": 5
+		}
+	]
+}

--- a/bench/io/config-weak-many-cores.json
+++ b/bench/io/config-weak-many-cores.json
@@ -1,0 +1,59 @@
+{
+	"os": "Operating system name and version",
+	"cpu": "Processor details",
+	"comment-server": "Server: -thread_count 15 -mode server",
+	"versions": {
+		"aio": {
+			"name": "mg::aio network",
+			"short_name": "mg::aio",
+			"exe": "bench_io",
+			"cmd": "-backend mg_aio -report summary -mode client"
+		},
+		"boost": {
+			"name": "boost::asio network",
+			"short_name": "boost::asio",
+			"exe": "bench_io",
+			"cmd": "-backend boost_asio -report summary -mode client",
+			"cond": "-test 1 -backend boost_asio"
+		}
+	},
+	"main_version": "aio",
+	"metric_key": "Message/sec(med)",
+	"metric_name": "messages per second",
+	"precision": 0.01,
+	"scenarios": [
+		{
+			"name": "Basic",
+			"cmd": "-thread_count 10 -connect_count_per_port 500 -message_payload_size 128 -message_int_count 5 -message_target_count 5000000",
+			"count": 5
+		},
+		{
+			"name": "Single thread",
+			"cmd": "-thread_count 1 -connect_count_per_port 500 -message_payload_size 128 -message_int_count 5 -message_target_count 2000000",
+			"count": 3
+		},
+		{
+			"name": "10 threads 100kb messages",
+			"cmd": "-thread_count 10 -connect_count_per_port 600 -message_payload_size 102400",
+			"count": 5,
+			"versions": {
+				"aio": {
+					"cmd": "-message_target_count 800000"
+				},
+				"boost": {
+					"cmd": "-message_target_count 100000"
+				}
+			}
+		},
+		{
+			"name": "Parallel messages",
+			"cmd": "-thread_count 10 -connect_count_per_port 500 -message_payload_size 128 -message_parallel_count 5 -message_target_count 20000000",
+			"count": 5
+		},
+		{
+			"name": "Massively parallel",
+			"cmd": "-thread_count 20 -connect_count_per_port 5000 -message_payload_size 128 -message_target_count 20000000",
+			"count": 5
+		}
+	]
+}

--- a/bench/io/config-weak.json
+++ b/bench/io/config-weak.json
@@ -1,0 +1,54 @@
+{
+	"os": "Operating system name and version",
+	"cpu": "Processor details",
+	"comment-server": "Server: -thread_count 3 -mode server",
+	"versions": {
+		"aio": {
+			"name": "mg::aio network",
+			"short_name": "mg::aio",
+			"exe": "bench_io",
+			"cmd": "-backend mg_aio -report summary -mode client"
+		},
+		"boost": {
+			"name": "boost::asio network",
+			"short_name": "boost::asio",
+			"exe": "bench_io",
+			"cmd": "-backend boost_asio -report summary -mode client",
+			"cond": "-test 1 -backend boost_asio"
+		}
+	},
+	"main_version": "aio",
+	"metric_key": "Message/sec(med)",
+	"metric_name": "messages per second",
+	"precision": 0.01,
+	"scenarios": [
+		{
+			"name": "Basic",
+			"cmd": "-thread_count 3 -connect_count_per_port 100 -message_payload_size 128 -message_int_count 5 -message_target_count 2500000",
+			"count": 3
+		},
+		{
+			"name": "Single thread",
+			"cmd": "-thread_count 1 -connect_count_per_port 100 -message_payload_size 128 -message_int_count 5 -message_target_count 2000000",
+			"count": 3
+		},
+		{
+			"name": "3 threads 100kb messages",
+			"cmd": "-thread_count 3 -connect_count_per_port 200 -message_payload_size 102400",
+			"count": 3,
+			"versions": {
+				"aio": {
+					"cmd": "-message_target_count 200000"
+				},
+				"boost": {
+					"cmd": "-message_target_count 150000"
+				}
+			}
+		},
+		{
+			"name": "Parallel messages",
+			"cmd": "-thread_count 3 -connect_count_per_port 100 -message_payload_size 128 -message_parallel_count 5 -message_target_count 20000000",
+			"count": 3
+		}
+	]
+}

--- a/bench/io/results/res_debian11_32core_64log_2500mhz.md
+++ b/bench/io/results/res_debian11_32core_64log_2500mhz.md
@@ -1,0 +1,242 @@
+**OS**: Debian GNU/Linux 11 (bullseye)<br>
+**CPU**: AMD EPYC 7502P 32-Core Processor 2.5GHz, 32 CPUs, 2 threads per core
+
+---
+**Basic**
+
+```
+Command line args: -thread_count 10 -connect_count_per_port 1000 -message_payload_size 128 -message_int_count 5 -message_target_count 5000000
+Run count: 5
+Summary:
+* 609 007 messages per second;
+* x1.798 of boost::asio;
+```
+
+<details><summary>Details</summary>
+
+```
+#### mg::aio network
+== Aggregated report:
+Message/sec(med) min:         607 709
+Message/sec(med) median:      609 007
+Message/sec(med) max:         611 478
+
+== Median report:
+
+   Messages(total): 5060876
+     Duration(sec): 8.405000
+Message/sec(total): 602126
+  Message/sec(med): 609007
+  Message/sec(max): 619776
+   Latency ms(med): 1.635923
+   Latency ms(max): 1.709414
+
+#### boost::asio network
+== Aggregated report:
+Message/sec(med) min:         336 186
+Message/sec(med) median:      338 688
+Message/sec(med) max:         341 755
+
+== Median report:
+
+   Messages(total): 5003124
+     Duration(sec): 14.608000
+Message/sec(total): 342492
+  Message/sec(med): 338688
+  Message/sec(max): 362109
+   Latency ms(med): 2.926802
+   Latency ms(max): 2.968205
+```
+</details>
+
+---
+**Single thread**
+
+```
+Command line args: -thread_count 1 -connect_count_per_port 1000 -message_payload_size 128 -message_int_count 5 -message_target_count 2000000
+Run count: 3
+Summary:
+* 114 479 messages per second;
+* x1.225 of boost::asio;
+```
+
+<details><summary>Details</summary>
+
+```
+#### mg::aio network
+== Aggregated report:
+Message/sec(med) min:         114 226
+Message/sec(med) median:      114 479
+Message/sec(med) max:         115 570
+
+== Median report:
+
+   Messages(total): 2007130
+     Duration(sec): 17.710000
+Message/sec(total): 113333
+  Message/sec(med): 114479
+  Message/sec(max): 117159
+   Latency ms(med): 8.725044
+   Latency ms(max): 10.152230
+
+#### boost::asio network
+== Aggregated report:
+Message/sec(med) min:          93 344
+Message/sec(med) median:       93 490
+Message/sec(med) max:          94 987
+
+== Median report:
+
+   Messages(total): 2004108
+     Duration(sec): 21.312000
+Message/sec(total): 94036
+  Message/sec(med): 93490
+  Message/sec(max): 97710
+   Latency ms(med): 10.609342
+   Latency ms(max): 10.950025
+```
+</details>
+
+---
+**10 threads 100kb messages**
+
+```
+Command line args: -thread_count 10 -connect_count_per_port 1000 -message_payload_size 102400
+Run count: 5
+Summary:
+* 37 659 messages per second;
+* x1.775 of boost::asio;
+```
+
+<details><summary>Details</summary>
+
+```
+#### mg::aio network
+== Aggregated report:
+Message/sec(med) min:          37 530
+Message/sec(med) median:       37 659
+Message/sec(med) max:          37 989
+
+== Median report:
+
+   Messages(total): 801224
+     Duration(sec): 21.514000
+Message/sec(total): 37241
+  Message/sec(med): 37659
+  Message/sec(max): 38166
+   Latency ms(med): 26.562961
+   Latency ms(max): 37.849462
+
+#### boost::asio network
+== Aggregated report:
+Message/sec(med) min:          20 724
+Message/sec(med) median:       21 220
+Message/sec(med) max:          21 681
+
+== Median report:
+
+   Messages(total): 100505
+     Duration(sec): 4.802000
+Message/sec(total): 20929
+  Message/sec(med): 21220
+  Message/sec(max): 21467
+   Latency ms(med): 46.769218
+   Latency ms(max): 47.220788
+```
+</details>
+
+---
+**Parallel messages**
+
+```
+Command line args: -thread_count 10 -connect_count_per_port 1000 -message_payload_size 128 -message_parallel_count 5 -message_target_count 20000000
+Run count: 5
+Summary:
+* 2 546 825 messages per second;
+* x1.581 of boost::asio;
+```
+
+<details><summary>Details</summary>
+
+```
+#### mg::aio network
+== Aggregated report:
+Message/sec(med) min:       2 536 287
+Message/sec(med) median:    2 546 825
+Message/sec(med) max:       2 615 275
+
+== Median report:
+
+   Messages(total): 20035245
+     Duration(sec): 8.005000
+Message/sec(total): 2502841
+  Message/sec(med): 2546825
+  Message/sec(max): 2556014
+   Latency ms(med): 1.964303
+   Latency ms(max): 2.175952
+
+#### boost::asio network
+== Aggregated report:
+Message/sec(med) min:       1 594 898
+Message/sec(med) median:    1 611 287
+Message/sec(med) max:       1 664 614
+
+== Median report:
+
+   Messages(total): 20101105
+     Duration(sec): 12.406000
+Message/sec(total): 1620272
+  Message/sec(med): 1611287
+  Message/sec(max): 1665387
+   Latency ms(med): 3.093927
+   Latency ms(max): 3.170195
+```
+</details>
+
+---
+**Massively parallel**
+
+```
+Command line args: -thread_count 20 -connect_count_per_port 5000 -message_payload_size 128 -message_target_count 10000000
+Run count: 5
+Summary:
+* 683 911 messages per second;
+* x2.186 of boost::asio;
+```
+
+<details><summary>Details</summary>
+
+```
+#### mg::aio network
+== Aggregated report:
+Message/sec(med) min:         681 141
+Message/sec(med) median:      683 911
+Message/sec(med) max:         684 789
+
+== Median report:
+
+   Messages(total): 10028739
+     Duration(sec): 14.909000
+Message/sec(total): 672663
+  Message/sec(med): 683911
+  Message/sec(max): 689684
+   Latency ms(med): 7.302698
+   Latency ms(max): 7.657709
+
+#### boost::asio network
+== Aggregated report:
+Message/sec(med) min:         308 292
+Message/sec(med) median:      312 847
+Message/sec(med) max:         317 201
+
+== Median report:
+
+   Messages(total): 10015201
+     Duration(sec): 31.919000
+Message/sec(total): 313769
+  Message/sec(med): 312847
+  Message/sec(max): 321314
+   Latency ms(med): 15.971300
+   Latency ms(max): 16.211111
+```
+</details>

--- a/bench/io/results/res_mac10_4core_8log_2500mhz.md
+++ b/bench/io/results/res_mac10_4core_8log_2500mhz.md
@@ -1,0 +1,194 @@
+**OS**: macOS Big Sur 11.7.10<br>
+**CPU**: Quad-Core Intel Core i7 2.5 GHz, 4 cores, hyper-threading enabled
+
+---
+**Basic**
+
+```
+Command line args: -thread_count 3 -connect_count_per_port 100 -message_payload_size 128 -message_int_count 5 -message_target_count 2500000
+Run count: 3
+Summary:
+* 146 932 messages per second;
+* x1.501 of boost::asio;
+```
+
+<details><summary>Details</summary>
+
+```
+#### mg::aio network
+== Aggregated report:
+Message/sec(med) min:         142 939
+Message/sec(med) median:      146 932
+Message/sec(med) max:         166 093
+
+== Median report:
+
+   Messages(total): 2513321
+     Duration(sec): 17.563000
+Message/sec(total): 143103
+  Message/sec(med): 146932
+  Message/sec(max): 156787
+   Latency ms(med): 0.694889
+   Latency ms(max): 0.761669
+
+#### boost::asio network
+== Aggregated report:
+Message/sec(med) min:          96 619
+Message/sec(med) median:       97 883
+Message/sec(med) max:          98 723
+
+== Median report:
+
+   Messages(total): 2509649
+     Duration(sec): 26.832000
+Message/sec(total): 93531
+  Message/sec(med): 97883
+  Message/sec(max): 102036
+   Latency ms(med): 1.032069
+   Latency ms(max): 1.450607
+```
+</details>
+
+---
+**Single thread**
+
+```
+Command line args: -thread_count 1 -connect_count_per_port 100 -message_payload_size 128 -message_int_count 5 -message_target_count 2000000
+Run count: 3
+Summary:
+* 101 800 messages per second;
+* x1.413 of boost::asio;
+```
+
+<details><summary>Details</summary>
+
+```
+#### mg::aio network
+== Aggregated report:
+Message/sec(med) min:          97 492
+Message/sec(med) median:      101 800
+Message/sec(med) max:         103 656
+
+== Median report:
+
+   Messages(total): 2006404
+     Duration(sec): 20.083000
+Message/sec(total): 99905
+  Message/sec(med): 101800
+  Message/sec(max): 109913
+   Latency ms(med): 0.999297
+   Latency ms(max): 1.279684
+
+#### boost::asio network
+== Aggregated report:
+Message/sec(med) min:          70 682
+Message/sec(med) median:       72 026
+Message/sec(med) max:          72 916
+
+== Median report:
+
+   Messages(total): 2001185
+     Duration(sec): 28.252000
+Message/sec(total): 70833
+  Message/sec(med): 72026
+  Message/sec(max): 75928
+   Latency ms(med): 1.399461
+   Latency ms(max): 1.595153
+```
+</details>
+
+---
+**3 threads 100kb messages**
+
+```
+Command line args: -thread_count 3 -connect_count_per_port 200 -message_payload_size 102400
+Run count: 3
+Summary:
+* 12 752 messages per second;
+* x1.452 of boost::asio;
+```
+
+<details><summary>Details</summary>
+
+```
+#### mg::aio network
+== Aggregated report:
+Message/sec(med) min:          12 719
+Message/sec(med) median:       12 752
+Message/sec(med) max:          13 002
+
+== Median report:
+
+   Messages(total): 200146
+     Duration(sec): 16.312000
+Message/sec(total): 12269
+  Message/sec(med): 12752
+  Message/sec(max): 13347
+   Latency ms(med): 15.962933
+   Latency ms(max): 19.018281
+
+#### boost::asio network
+== Aggregated report:
+Message/sec(med) min:           8 567
+Message/sec(med) median:        8 780
+Message/sec(med) max:           9 053
+
+== Median report:
+
+   Messages(total): 150925
+     Duration(sec): 17.594000
+Message/sec(total): 8578
+  Message/sec(med): 8780
+  Message/sec(max): 9337
+   Latency ms(med): 22.705103
+   Latency ms(max): 26.485947
+```
+</details>
+
+---
+**Parallel messages**
+
+```
+Command line args: -thread_count 3 -connect_count_per_port 100 -message_payload_size 128 -message_parallel_count 5 -message_target_count 20000000
+Run count: 3
+Summary:
+* 712 243 messages per second;
+* x1.536 of boost::asio;
+```
+
+<details><summary>Details</summary>
+
+```
+#### mg::aio network
+== Aggregated report:
+Message/sec(med) min:         688 768
+Message/sec(med) median:      712 243
+Message/sec(med) max:         713 392
+
+== Median report:
+
+   Messages(total): 20016525
+     Duration(sec): 28.904000
+Message/sec(total): 692517
+  Message/sec(med): 712243
+  Message/sec(max): 725235
+   Latency ms(med): 0.718574
+   Latency ms(max): 0.793306
+
+#### boost::asio network
+== Aggregated report:
+Message/sec(med) min:         463 117
+Message/sec(med) median:      463 717
+Message/sec(med) max:         463 827
+
+== Median report:
+
+   Messages(total): 20045095
+     Duration(sec): 43.940000
+Message/sec(total): 456192
+  Message/sec(med): 463717
+  Message/sec(max): 478038
+   Latency ms(med): 1.092702
+   Latency ms(max): 1.174814
+```
+</details>

--- a/bench/io/results/res_ubuntu22_24core_48log_4800mhz.md
+++ b/bench/io/results/res_ubuntu22_24core_48log_4800mhz.md
@@ -1,0 +1,194 @@
+**OS**: Ubuntu 22.04.4 LTS<br>
+**CPU**: 12th Gen Intel(R) Core(TM) i7-12800HX 0.8-4.8GHz, 24 CPUs, 2 threads per core
+
+---
+**Basic**
+
+```
+Command line args: -thread_count 5 -connect_count_per_port 100 -message_payload_size 128 -message_int_count 5 -message_target_count 5000000
+Run count: 5
+Summary:
+* 962 631 messages per second;
+* x1.549 of boost::asio;
+```
+
+<details><summary>Details</summary>
+
+```
+#### mg::aio network
+== Aggregated report:
+Message/sec(med) min:         936 950
+Message/sec(med) median:      962 631
+Message/sec(med) max:         966 197
+
+== Median report:
+
+   Messages(total): 5046319
+     Duration(sec): 5.304000
+Message/sec(total): 951417
+  Message/sec(med): 962631
+  Message/sec(max): 979690
+   Latency ms(med): 0.103917
+   Latency ms(max): 0.326609
+
+#### boost::asio network
+== Aggregated report:
+Message/sec(med) min:         607 149
+Message/sec(med) median:      621 455
+Message/sec(med) max:         634 508
+
+== Median report:
+
+   Messages(total): 5026974
+     Duration(sec): 8.107000
+Message/sec(total): 620078
+  Message/sec(med): 621455
+  Message/sec(max): 633177
+   Latency ms(med): 0.160041
+   Latency ms(max): 0.164533
+```
+</details>
+
+---
+**Single thread**
+
+```
+Command line args: -thread_count 1 -connect_count_per_port 100 -message_payload_size 128 -message_int_count 5 -message_target_count 2000000
+Run count: 5
+Summary:
+* 330 202 messages per second;
+* x1.459 of boost::asio;
+```
+
+<details><summary>Details</summary>
+
+```
+#### mg::aio network
+== Aggregated report:
+Message/sec(med) min:         328 713
+Message/sec(med) median:      330 202
+Message/sec(med) max:         331 758
+
+== Median report:
+
+   Messages(total): 2027516
+     Duration(sec): 6.204000
+Message/sec(total): 326807
+  Message/sec(med): 330202
+  Message/sec(max): 332413
+   Latency ms(med): 0.302987
+   Latency ms(max): 0.444898
+
+#### boost::asio network
+== Aggregated report:
+Message/sec(med) min:         223 622
+Message/sec(med) median:      226 385
+Message/sec(med) max:         226 921
+
+== Median report:
+
+   Messages(total): 2007201
+     Duration(sec): 8.907000
+Message/sec(total): 225350
+  Message/sec(med): 226385
+  Message/sec(max): 227019
+   Latency ms(med): 0.441120
+   Latency ms(max): 0.451560
+```
+</details>
+
+---
+**5 threads 100kb messages**
+
+```
+Command line args: -thread_count 5 -connect_count_per_port 200 -message_payload_size 102400
+Run count: 5
+Summary:
+* 51 105 messages per second;
+* x4.444 of boost::asio;
+```
+
+<details><summary>Details</summary>
+
+```
+#### mg::aio network
+== Aggregated report:
+Message/sec(med) min:          50 036
+Message/sec(med) median:       51 105
+Message/sec(med) max:          51 451
+
+== Median report:
+
+   Messages(total): 800427
+     Duration(sec): 15.812000
+Message/sec(total): 50621
+  Message/sec(med): 51105
+  Message/sec(max): 52767
+   Latency ms(med): 3.903223
+   Latency ms(max): 13.473545
+
+#### boost::asio network
+== Aggregated report:
+Message/sec(med) min:          10 743
+Message/sec(med) median:       11 501
+Message/sec(med) max:          11 815
+
+== Median report:
+
+   Messages(total): 100672
+     Duration(sec): 9.008000
+Message/sec(total): 11175
+  Message/sec(med): 11501
+  Message/sec(max): 12452
+   Latency ms(med): 17.407676
+   Latency ms(max): 27.633073
+```
+</details>
+
+---
+**Parallel messages**
+
+```
+Command line args: -thread_count 5 -connect_count_per_port 100 -message_payload_size 128 -message_parallel_count 5 -message_target_count 20000000
+Run count: 5
+Summary:
+* 4 001 805 messages per second;
+* x1.917 of boost::asio;
+```
+
+<details><summary>Details</summary>
+
+```
+#### mg::aio network
+== Aggregated report:
+Message/sec(med) min:       3 899 441
+Message/sec(med) median:    4 001 805
+Message/sec(med) max:       4 122 601
+
+== Median report:
+
+   Messages(total): 20340485
+     Duration(sec): 5.205000
+Message/sec(total): 3907874
+  Message/sec(med): 4001805
+  Message/sec(max): 4058287
+   Latency ms(med): 0.125062
+   Latency ms(max): 0.515268
+
+#### boost::asio network
+== Aggregated report:
+Message/sec(med) min:       1 665 533
+Message/sec(med) median:    2 087 534
+Message/sec(med) max:       2 921 384
+
+== Median report:
+
+   Messages(total): 20032435
+     Duration(sec): 9.006000
+Message/sec(total): 2224343
+  Message/sec(med): 2087534
+  Message/sec(max): 2895183
+   Latency ms(med): 0.178412
+   Latency ms(max): 0.337385
+```
+</details>

--- a/bench/io/results/res_windows11_12core_24log_3700mhz_weak.md
+++ b/bench/io/results/res_windows11_12core_24log_3700mhz_weak.md
@@ -1,0 +1,194 @@
+**OS**: Windows 11 Home 23H2 22631.3737<br>
+**CPU**: AMD Ryzen 9 5900X 12-Core Processor 3.70 GHz, 12 Cores, 24 Logical Processors
+
+---
+**Basic**
+
+```
+Command line args: -thread_count 3 -connect_count_per_port 100 -message_payload_size 128 -message_int_count 5 -message_target_count 2500000
+Run count: 3
+Summary:
+* 195 436 messages per second;
+* x1.101 of boost::asio;
+```
+
+<details><summary>Details</summary>
+
+```
+#### mg::aio network
+== Aggregated report:
+Message/sec(med) min:         193 519
+Message/sec(med) median:      195 436
+Message/sec(med) max:         197 225
+
+== Median report:
+
+   Messages(total): 2501623
+     Duration(sec): 14.016000
+Message/sec(total): 178483
+  Message/sec(med): 195436
+  Message/sec(max): 196154
+   Latency ms(med): 0.559572
+   Latency ms(max): 0.563687
+
+#### boost::asio network
+== Aggregated report:
+Message/sec(med) min:         176 346
+Message/sec(med) median:      177 584
+Message/sec(med) max:         179 157
+
+== Median report:
+
+   Messages(total): 2515646
+     Duration(sec): 15.531000
+Message/sec(total): 161975
+  Message/sec(med): 177584
+  Message/sec(max): 181047
+   Latency ms(med): 0.614552
+   Latency ms(max): 0.644101
+```
+</details>
+
+---
+**Single thread**
+
+```
+Command line args: -thread_count 1 -connect_count_per_port 100 -message_payload_size 128 -message_int_count 5 -message_target_count 2000000
+Run count: 3
+Summary:
+* 80 510 messages per second;
+* x1.200 of boost::asio;
+```
+
+<details><summary>Details</summary>
+
+```
+#### mg::aio network
+== Aggregated report:
+Message/sec(med) min:          80 330
+Message/sec(med) median:       80 510
+Message/sec(med) max:          80 977
+
+== Median report:
+
+   Messages(total): 2006655
+     Duration(sec): 27.343000
+Message/sec(total): 73388
+  Message/sec(med): 80510
+  Message/sec(max): 81671
+   Latency ms(med): 1.357757
+   Latency ms(max): 1.422896
+
+#### boost::asio network
+== Aggregated report:
+Message/sec(med) min:          66 361
+Message/sec(med) median:       67 091
+Message/sec(med) max:          68 532
+
+== Median report:
+
+   Messages(total): 2004338
+     Duration(sec): 32.266000
+Message/sec(total): 62119
+  Message/sec(med): 67091
+  Message/sec(max): 71486
+   Latency ms(med): 1.622270
+   Latency ms(max): 1.657626
+```
+</details>
+
+---
+**3 threads 100kb messages**
+
+```
+Command line args: -thread_count 3 -connect_count_per_port 200 -message_payload_size 102400
+Run count: 3
+Summary:
+* 28 368 messages per second;
+* x2.112 of boost::asio;
+```
+
+<details><summary>Details</summary>
+
+```
+#### mg::aio network
+== Aggregated report:
+Message/sec(med) min:          28 039
+Message/sec(med) median:       28 368
+Message/sec(med) max:          28 788
+
+== Median report:
+
+   Messages(total): 201354
+     Duration(sec): 7.765000
+Message/sec(total): 25930
+  Message/sec(med): 28368
+  Message/sec(max): 28599
+   Latency ms(med): 7.691767
+   Latency ms(max): 7.846596
+
+#### boost::asio network
+== Aggregated report:
+Message/sec(med) min:          10 923
+Message/sec(med) median:       13 431
+Message/sec(med) max:          13 548
+
+== Median report:
+
+   Messages(total): 150910
+     Duration(sec): 12.265000
+Message/sec(total): 12304
+  Message/sec(med): 13431
+  Message/sec(max): 13657
+   Latency ms(med): 16.256789
+   Latency ms(max): 16.465809
+```
+</details>
+
+---
+**Parallel messages**
+
+```
+Command line args: -thread_count 3 -connect_count_per_port 100 -message_payload_size 128 -message_parallel_count 5 -message_target_count 20000000
+Run count: 3
+Summary:
+* 730 270 messages per second;
+* x1.066 of boost::asio;
+```
+
+<details><summary>Details</summary>
+
+```
+#### mg::aio network
+== Aggregated report:
+Message/sec(med) min:         686 030
+Message/sec(med) median:      730 270
+Message/sec(med) max:         789 652
+
+== Median report:
+
+   Messages(total): 20077660
+     Duration(sec): 29.531000
+Message/sec(total): 679884
+  Message/sec(med): 730270
+  Message/sec(max): 851047
+   Latency ms(med): 0.747578
+   Latency ms(max): 0.830214
+
+#### boost::asio network
+== Aggregated report:
+Message/sec(med) min:         634 260
+Message/sec(med) median:      685 192
+Message/sec(med) max:         685 524
+
+== Median report:
+
+   Messages(total): 20044200
+     Duration(sec): 30.766000
+Message/sec(total): 651504
+  Message/sec(med): 685192
+  Message/sec(max): 835312
+   Latency ms(med): 0.763405
+   Latency ms(max): 0.846458
+```
+</details>

--- a/bench/io/results/res_windows11_12core_24log_3700mhz_weak_many_cores.md
+++ b/bench/io/results/res_windows11_12core_24log_3700mhz_weak_many_cores.md
@@ -1,0 +1,242 @@
+**OS**: Windows 11 Home 23H2 22631.3737<br>
+**CPU**: AMD Ryzen 9 5900X 12-Core Processor 3.70 GHz, 12 Cores, 24 Logical Processors
+
+---
+**Basic**
+
+```
+Command line args: -thread_count 10 -connect_count_per_port 500 -message_payload_size 128 -message_int_count 5 -message_target_count 5000000
+Run count: 5
+Summary:
+* 209 571 messages per second;
+* x0.930 of boost::asio;
+```
+
+<details><summary>Details</summary>
+
+```
+#### mg::aio network
+== Aggregated report:
+Message/sec(med) min:         207 660
+Message/sec(med) median:      209 571
+Message/sec(med) max:         209 787
+
+== Median report:
+
+   Messages(total): 5018710
+     Duration(sec): 26.250000
+Message/sec(total): 191188
+  Message/sec(med): 209571
+  Message/sec(max): 210788
+   Latency ms(med): 2.607049
+   Latency ms(max): 2.653654
+
+#### boost::asio network
+== Aggregated report:
+Message/sec(med) min:         217 438
+Message/sec(med) median:      225 316
+Message/sec(med) max:         231 364
+
+== Median report:
+
+   Messages(total): 5020912
+     Duration(sec): 23.828000
+Message/sec(total): 210714
+  Message/sec(med): 225316
+  Message/sec(max): 240984
+   Latency ms(med): 2.355898
+   Latency ms(max): 2.493085
+```
+</details>
+
+---
+**Single thread**
+
+```
+Command line args: -thread_count 1 -connect_count_per_port 500 -message_payload_size 128 -message_int_count 5 -message_target_count 2000000
+Run count: 3
+Summary:
+* 64 341 messages per second;
+* x1.259 of boost::asio;
+```
+
+<details><summary>Details</summary>
+
+```
+#### mg::aio network
+== Aggregated report:
+Message/sec(med) min:          62 153
+Message/sec(med) median:       64 341
+Message/sec(med) max:          64 644
+
+== Median report:
+
+   Messages(total): 2003890
+     Duration(sec): 35.812000
+Message/sec(total): 55955
+  Message/sec(med): 64341
+  Message/sec(max): 64810
+   Latency ms(med): 8.499118
+   Latency ms(max): 11.203871
+
+#### boost::asio network
+== Aggregated report:
+Message/sec(med) min:          47 344
+Message/sec(med) median:       51 121
+Message/sec(med) max:          51 897
+
+== Median report:
+
+   Messages(total): 2006434
+     Duration(sec): 43.297000
+Message/sec(total): 46341
+  Message/sec(med): 51121
+  Message/sec(max): 62289
+   Latency ms(med): 10.688741
+   Latency ms(max): 13.429185
+```
+</details>
+
+---
+**10 threads 100kb messages**
+
+```
+Command line args: -thread_count 10 -connect_count_per_port 600 -message_payload_size 102400
+Run count: 5
+Summary:
+* 26 289 messages per second;
+* x1.525 of boost::asio;
+```
+
+<details><summary>Details</summary>
+
+```
+#### mg::aio network
+== Aggregated report:
+Message/sec(med) min:          25 933
+Message/sec(med) median:       26 289
+Message/sec(med) max:          26 643
+
+== Median report:
+
+   Messages(total): 801691
+     Duration(sec): 33.687000
+Message/sec(total): 23798
+  Message/sec(med): 26289
+  Message/sec(max): 26459
+   Latency ms(med): 24.843308
+   Latency ms(max): 27.677855
+
+#### boost::asio network
+== Aggregated report:
+Message/sec(med) min:          16 719
+Message/sec(med) median:       17 235
+Message/sec(med) max:          17 312
+
+== Median report:
+
+   Messages(total): 100563
+     Duration(sec): 6.359000
+Message/sec(total): 15814
+  Message/sec(med): 17235
+  Message/sec(max): 17620
+   Latency ms(med): 37.777998
+   Latency ms(max): 38.581990
+```
+</details>
+
+---
+**Parallel messages**
+
+```
+Command line args: -thread_count 10 -connect_count_per_port 500 -message_payload_size 128 -message_parallel_count 5 -message_target_count 20000000
+Run count: 5
+Summary:
+* 997 494 messages per second;
+* x0.854 of boost::asio;
+```
+
+<details><summary>Details</summary>
+
+```
+#### mg::aio network
+== Aggregated report:
+Message/sec(med) min:         987 949
+Message/sec(med) median:      997 494
+Message/sec(med) max:         999 332
+
+== Median report:
+
+   Messages(total): 20031700
+     Duration(sec): 22.031000
+Message/sec(total): 909250
+  Message/sec(med): 997494
+  Message/sec(max): 1011665
+   Latency ms(med): 2.730070
+   Latency ms(max): 2.819511
+
+#### boost::asio network
+== Aggregated report:
+Message/sec(med) min:       1 157 859
+Message/sec(med) median:    1 168 372
+Message/sec(med) max:       1 170 332
+
+== Median report:
+
+   Messages(total): 20056850
+     Duration(sec): 18.890000
+Message/sec(total): 1061770
+  Message/sec(med): 1168372
+  Message/sec(max): 1171106
+   Latency ms(med): 2.339200
+   Latency ms(max): 2.455831
+```
+</details>
+
+---
+**Massively parallel**
+
+```
+Command line args: -thread_count 20 -connect_count_per_port 5000 -message_payload_size 128 -message_target_count 20000000
+Run count: 5
+Summary:
+* 219 826 messages per second;
+* x1.265 of boost::asio;
+```
+
+<details><summary>Details</summary>
+
+```
+#### mg::aio network
+== Aggregated report:
+Message/sec(med) min:         218 536
+Message/sec(med) median:      219 826
+Message/sec(med) max:         220 636
+
+== Median report:
+
+   Messages(total): 20017948
+     Duration(sec): 109.297000
+Message/sec(total): 183151
+  Message/sec(med): 219826
+  Message/sec(max): 279886
+   Latency ms(med): 24.866879
+   Latency ms(max): 2154.285714
+
+#### boost::asio network
+== Aggregated report:
+Message/sec(med) min:         173 593
+Message/sec(med) median:      173 773
+Message/sec(med) max:         175 029
+
+== Median report:
+
+   Messages(total): 20013042
+     Duration(sec): 159.390000
+Message/sec(total): 125560
+  Message/sec(med): 173773
+  Message/sec(max): 207545
+   Latency ms(med): 30.908909
+   Latency ms(max): 1032.921206
+```
+</details>

--- a/bench/io/results/res_wsl1_12core_24log_3700mhz_strong.md
+++ b/bench/io/results/res_wsl1_12core_24log_3700mhz_strong.md
@@ -1,0 +1,194 @@
+**OS**: WSL 1 Linux 5.10.16.3-22631-Microsoft on Windows 11 Home 23H2<br>
+**CPU**: AMD Ryzen 9 5900X 12-Core Processor 3.70 GHz, 12 Cores, 24 Logical Processors
+
+---
+**Basic**
+
+```
+Command line args: -thread_count 5 -connect_count_per_port 100 -message_payload_size 128 -message_int_count 5 -message_target_count 5000000
+Run count: 5
+Summary:
+* 706 873 messages per second;
+* x1.324 of boost::asio;
+```
+
+<details><summary>Details</summary>
+
+```
+#### mg::aio network
+== Aggregated report:
+Message/sec(med) min:         695 457
+Message/sec(med) median:      706 873
+Message/sec(med) max:         710 776
+
+== Median report:
+
+   Messages(total): 5007435
+     Duration(sec): 7.105000
+Message/sec(total): 704776
+  Message/sec(med): 706873
+  Message/sec(max): 712742
+   Latency ms(med): 0.141284
+   Latency ms(max): 0.152482
+
+#### boost::asio network
+== Aggregated report:
+Message/sec(med) min:         533 028
+Message/sec(med) median:      533 740
+Message/sec(med) max:         535 952
+
+== Median report:
+
+   Messages(total): 5012275
+     Duration(sec): 9.407000
+Message/sec(total): 532823
+  Message/sec(med): 533740
+  Message/sec(max): 535275
+   Latency ms(med): 0.187273
+   Latency ms(max): 0.187896
+```
+</details>
+
+---
+**Single thread**
+
+```
+Command line args: -thread_count 1 -connect_count_per_port 100 -message_payload_size 128 -message_int_count 5 -message_target_count 2000000
+Run count: 5
+Summary:
+* 427 610 messages per second;
+* x1.466 of boost::asio;
+```
+
+<details><summary>Details</summary>
+
+```
+#### mg::aio network
+== Aggregated report:
+Message/sec(med) min:         424 429
+Message/sec(med) median:      427 610
+Message/sec(med) max:         432 370
+
+== Median report:
+
+   Messages(total): 2010730
+     Duration(sec): 4.803000
+Message/sec(total): 418640
+  Message/sec(med): 427610
+  Message/sec(max): 431259
+   Latency ms(med): 0.233307
+   Latency ms(max): 0.294190
+
+#### boost::asio network
+== Aggregated report:
+Message/sec(med) min:         286 992
+Message/sec(med) median:      291 722
+Message/sec(med) max:         292 975
+
+== Median report:
+
+   Messages(total): 2012315
+     Duration(sec): 6.905000
+Message/sec(total): 291428
+  Message/sec(med): 291722
+  Message/sec(max): 293924
+   Latency ms(med): 0.340760
+   Latency ms(max): 0.343884
+```
+</details>
+
+---
+**5 threads 100kb messages**
+
+```
+Command line args: -thread_count 5 -connect_count_per_port 200 -message_payload_size 102400
+Run count: 5
+Summary:
+* 37 841 messages per second;
+* x1.218 of boost::asio;
+```
+
+<details><summary>Details</summary>
+
+```
+#### mg::aio network
+== Aggregated report:
+Message/sec(med) min:          35 452
+Message/sec(med) median:       37 841
+Message/sec(med) max:          38 337
+
+== Median report:
+
+   Messages(total): 802797
+     Duration(sec): 21.420000
+Message/sec(total): 37478
+  Message/sec(med): 37841
+  Message/sec(max): 38190
+   Latency ms(med): 5.290028
+   Latency ms(max): 10.307692
+
+#### boost::asio network
+== Aggregated report:
+Message/sec(med) min:          30 586
+Message/sec(med) median:       31 061
+Message/sec(med) max:          32 076
+
+== Median report:
+
+   Messages(total): 500861
+     Duration(sec): 16.115000
+Message/sec(total): 31080
+  Message/sec(med): 31061
+  Message/sec(max): 32260
+   Latency ms(med): 6.407472
+   Latency ms(max): 6.677111
+```
+</details>
+
+---
+**Parallel messages**
+
+```
+Command line args: -thread_count 5 -connect_count_per_port 100 -message_payload_size 128 -message_parallel_count 5 -message_target_count 20000000
+Run count: 5
+Summary:
+* 2 893 124 messages per second;
+* x1.259 of boost::asio;
+```
+
+<details><summary>Details</summary>
+
+```
+#### mg::aio network
+== Aggregated report:
+Message/sec(med) min:       2 815 825
+Message/sec(med) median:    2 893 124
+Message/sec(med) max:       3 111 272
+
+== Median report:
+
+   Messages(total): 20066550
+     Duration(sec): 7.006000
+Message/sec(total): 2864194
+  Message/sec(med): 2893124
+  Message/sec(max): 2933941
+   Latency ms(med): 0.172920
+   Latency ms(max): 0.177789
+
+#### boost::asio network
+== Aggregated report:
+Message/sec(med) min:       2 247 995
+Message/sec(med) median:    2 298 417
+Message/sec(med) max:       2 352 277
+
+== Median report:
+
+   Messages(total): 20119260
+     Duration(sec): 8.707000
+Message/sec(total): 2310699
+  Message/sec(med): 2298417
+  Message/sec(max): 2341130
+   Latency ms(med): 0.214996
+   Latency ms(max): 0.219003
+```
+</details>

--- a/bench/io/results/res_wsl1_12core_24log_3700mhz_weak_many_cores.md
+++ b/bench/io/results/res_wsl1_12core_24log_3700mhz_weak_many_cores.md
@@ -1,0 +1,242 @@
+**OS**: WSL 1 Linux 5.10.16.3-22631-Microsoft on Windows 11 Home 23H2<br>
+**CPU**: AMD Ryzen 9 5900X 12-Core Processor 3.70 GHz, 12 Cores, 24 Logical Processors
+
+---
+**Basic**
+
+```
+Command line args: -thread_count 10 -connect_count_per_port 500 -message_payload_size 128 -message_int_count 5 -message_target_count 5000000
+Run count: 5
+Summary:
+* 921 059 messages per second;
+* x1.512 of boost::asio;
+```
+
+<details><summary>Details</summary>
+
+```
+#### mg::aio network
+== Aggregated report:
+Message/sec(med) min:         907 942
+Message/sec(med) median:      921 059
+Message/sec(med) max:         927 274
+
+== Median report:
+
+   Messages(total): 5038214
+     Duration(sec): 5.604000
+Message/sec(total): 899038
+  Message/sec(med): 921059
+  Message/sec(max): 928396
+   Latency ms(med): 0.541244
+   Latency ms(max): 0.645764
+
+#### boost::asio network
+== Aggregated report:
+Message/sec(med) min:         605 861
+Message/sec(med) median:      609 030
+Message/sec(med) max:         614 712
+
+== Median report:
+
+   Messages(total): 5011328
+     Duration(sec): 8.307000
+Message/sec(total): 603265
+  Message/sec(med): 609030
+  Message/sec(max): 613320
+   Latency ms(med): 0.817909
+   Latency ms(max): 0.829520
+```
+</details>
+
+---
+**Single thread**
+
+```
+Command line args: -thread_count 1 -connect_count_per_port 500 -message_payload_size 128 -message_int_count 5 -message_target_count 2000000
+Run count: 3
+Summary:
+* 400 660 messages per second;
+* x1.472 of boost::asio;
+```
+
+<details><summary>Details</summary>
+
+```
+#### mg::aio network
+== Aggregated report:
+Message/sec(med) min:         398 469
+Message/sec(med) median:      400 660
+Message/sec(med) max:         401 120
+
+== Median report:
+
+   Messages(total): 2007145
+     Duration(sec): 5.103000
+Message/sec(total): 393326
+  Message/sec(med): 400660
+  Message/sec(max): 418829
+   Latency ms(med): 1.208844
+   Latency ms(max): 1.611556
+
+#### boost::asio network
+== Aggregated report:
+Message/sec(med) min:         269 012
+Message/sec(med) median:      272 249
+Message/sec(med) max:         279 134
+
+== Median report:
+
+   Messages(total): 2006153
+     Duration(sec): 7.405000
+Message/sec(total): 270918
+  Message/sec(med): 272249
+  Message/sec(max): 279467
+   Latency ms(med): 1.824674
+   Latency ms(max): 1.897719
+```
+</details>
+
+---
+**10 threads 100kb messages**
+
+```
+Command line args: -thread_count 10 -connect_count_per_port 600 -message_payload_size 102400
+Run count: 5
+Summary:
+* 24 825 messages per second;
+* x1.235 of boost::asio;
+```
+
+<details><summary>Details</summary>
+
+```
+#### mg::aio network
+== Aggregated report:
+Message/sec(med) min:          22 330
+Message/sec(med) median:       24 825
+Message/sec(med) max:          27 449
+
+== Median report:
+
+   Messages(total): 800335
+     Duration(sec): 33.240000
+Message/sec(total): 24077
+  Message/sec(med): 24825
+  Message/sec(max): 26186
+   Latency ms(med): 24.145689
+   Latency ms(max): 29.710149
+
+#### boost::asio network
+== Aggregated report:
+Message/sec(med) min:          19 792
+Message/sec(med) median:       20 101
+Message/sec(med) max:          21 314
+
+== Median report:
+
+   Messages(total): 100523
+     Duration(sec): 4.905000
+Message/sec(total): 20493
+  Message/sec(med): 20101
+  Message/sec(max): 20921
+   Latency ms(med): 28.839587
+   Latency ms(max): 29.969334
+```
+</details>
+
+---
+**Parallel messages**
+
+```
+Command line args: -thread_count 10 -connect_count_per_port 500 -message_payload_size 128 -message_parallel_count 5 -message_target_count 20000000
+Run count: 5
+Summary:
+* 4 202 329 messages per second;
+* x1.444 of boost::asio;
+```
+
+<details><summary>Details</summary>
+
+```
+#### mg::aio network
+== Aggregated report:
+Message/sec(med) min:       3 948 638
+Message/sec(med) median:    4 202 329
+Message/sec(med) max:       4 258 330
+
+== Median report:
+
+   Messages(total): 20401990
+     Duration(sec): 5.004000
+Message/sec(total): 4077136
+  Message/sec(med): 4202329
+  Message/sec(max): 4276682
+   Latency ms(med): 0.594593
+   Latency ms(max): 0.698283
+
+#### boost::asio network
+== Aggregated report:
+Message/sec(med) min:       2 801 545
+Message/sec(med) median:    2 910 192
+Message/sec(med) max:       2 916 322
+
+== Median report:
+
+   Messages(total): 20175095
+     Duration(sec): 7.006000
+Message/sec(total): 2879688
+  Message/sec(med): 2910192
+  Message/sec(max): 2937140
+   Latency ms(med): 0.853249
+   Latency ms(max): 0.862186
+```
+</details>
+
+---
+**Massively parallel**
+
+```
+Command line args: -thread_count 20 -connect_count_per_port 5000 -message_payload_size 128 -message_target_count 20000000
+Run count: 5
+Summary:
+* 968 353 messages per second;
+* x1.774 of boost::asio;
+```
+
+<details><summary>Details</summary>
+
+```
+#### mg::aio network
+== Aggregated report:
+Message/sec(med) min:         961 685
+Message/sec(med) median:      968 353
+Message/sec(med) max:       1 066 044
+
+== Median report:
+
+   Messages(total): 20031134
+     Duration(sec): 21.117000
+Message/sec(total): 948578
+  Message/sec(med): 968353
+  Message/sec(max): 1021764
+   Latency ms(med): 5.182636
+   Latency ms(max): 24.627660
+
+#### boost::asio network
+== Aggregated report:
+Message/sec(med) min:         541 812
+Message/sec(med) median:      545 793
+Message/sec(med) max:         552 065
+
+== Median report:
+
+   Messages(total): 20040159
+     Duration(sec): 37.167000
+Message/sec(total): 539192
+  Message/sec(med): 545793
+  Message/sec(max): 564159
+   Latency ms(med): 9.333711
+   Latency ms(max): 13.315223
+```
+</details>

--- a/src/mg/box/Thread_Unix.cpp
+++ b/src/mg/box/Thread_Unix.cpp
@@ -4,7 +4,6 @@
 
 #include <sys/syscall.h>
 #include <unistd.h>
-#include <xmmintrin.h>
 
 namespace mg {
 namespace box {


### PR DESCRIPTION
The results are collected on several machines and operating systems and compared with boost 1.69 and boost 1.84 (latest at the time of writing).

Also the patchset makes some fixes needed for the benches to work properly.