### PR TITLE
aio: preserve recv-queue between recv events

### DIFF
--- a/src/mg/aio/TCPSocket.cpp
+++ b/src/mg/aio/TCPSocket.cpp
@@ -100,10 +100,7 @@ namespace aio {
 		if (!PrivRecvEventConsume())
 			return;
 		if (myRecvSize == 0)
-		{
-			MG_BOX_ASSERT(myRecvQueue.IsEmpty());
 			return;
-		}
 		myRecvQueue.EnsureWriteSize(myRecvSize);
 		myTask.Recv(myRecvQueue.GetWritePos(), myRecvEvent);
 		if (!PrivRecvEventConsume())
@@ -134,12 +131,8 @@ namespace aio {
 		}
 		myRecvQueue.PropagateWritePos(aByteCount);
 		myRecvSize = 0;
-		{
-			mg::net::BufferReadStream stream(myRecvQueue);
-			ProtOnRecv(stream);
-		}
-		if (myRecvSize == 0)
-			myRecvQueue.Clear();
+		mg::net::BufferReadStream stream(myRecvQueue);
+		ProtOnRecv(stream);
 	}
 
 	bool


### PR DESCRIPTION
`TCPSocket::myRecvQueue` was cleared if during `OnRecv()` no new data was requested.

It could happen that the caller simply needed more data for a complete message and didn't consume the whole `myRecvQueue`. Discarding this data simply leads to the message corruption.

Lets better preserve the data.

It is easy tested in this patch by trying to send large messages, which won't be delivered in one piece.