### PR TITLE
Introduce timeouts for the tests and fix one of the cases in aio

### DIFF
--- a/test/UnitTest.cpp
+++ b/test/UnitTest.cpp
@@ -27,6 +27,7 @@ namespace unittests {
 	{
 		vprintf(aFormat, aArg);
 		printf("\n");
+		fflush(stdout);
 	}
 
 	TestSuiteGuard::TestSuiteGuard(

--- a/test/UnitTest.h
+++ b/test/UnitTest.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "mg/box/Assert.h"
+#include "mg/box/Thread.h"
 
 #include <cstdarg>
 
@@ -15,6 +16,8 @@
 #endif
 
 #define TEST_CHECK MG_BOX_ASSERT
+#define TEST_YIELD_PERIOD 5
+#define TEST_TIMEOUT 300000 // 5 mins
 
 namespace mg {
 namespace unittests {
@@ -52,6 +55,19 @@ namespace unittests {
 	private:
 		double myStartMs;
 	};
+
+	template <typename T>
+	static inline void
+	Wait(T&& aCondition, uint32_t aPeriodMs = TEST_YIELD_PERIOD, uint32_t aTimeout = TEST_TIMEOUT)
+	{
+		uint64_t deadline = mg::box::GetMilliseconds() + aTimeout;
+		while (!aCondition())
+		{
+			TEST_CHECK(mg::box::GetMilliseconds() < deadline);
+			if (aPeriodMs != 0)
+				mg::box::Sleep(aPeriodMs);
+		}
+	}
 
 }
 }


### PR DESCRIPTION
Looking just at the CI doesn't seem reliable. Timing out tests not always produce any stdout. Perhaps a manual explicit test stop would flush stdout better.

Also the stress reconnect test in aio suite was revealed as hanging thanks to those timeouts and stdout flushes. It is fixed now.