### PR TITLE
sch: don't receive front signal all the time

### DIFF
--- a/src/mg/sch/TaskScheduler.cpp
+++ b/src/mg/sch/TaskScheduler.cpp
@@ -130,10 +130,13 @@ namespace sch {
 		// -------------------------------------------------------
 		// Handle front tasks.
 
-		mySignalFront.Receive();
 		// Popping the front queue takes linear time due to how the multi-producer queue
 		// is implemented. It is not batched so far, but even for millions of tasks it is
 		// a few milliseconds tops.
+		// Note, the front signal is not received, because under a high load the queue is
+		// rarely expected to be empty. So receiving this signal would be pointless. At
+		// the same time, if the queue does become empty for a while, the front signal is
+		// received when the scheduler has nothing to do and goes to sleep on that signal.
 		t = myQueueFront.PopAll(tail);
 		myQueuePending.Append(t, tail);
 		batch = 0;


### PR DESCRIPTION
No need to receive it on each scheduling iteration. Under a high load it won't change anything, because the queue is never empty. The signal would be set again right away after receiving.

OTOH, not consuming it on each iteration doesn't break the logic, because when the scheduler has nothing to do, it will sleep on the signal. And if it was set, it would then be received.

This optimization leads to a spurious wakeup under no load. But removes a needless signal receipt on a hot path.

The benchmarks though didn't show any difference. At least on Apple Silicon M1. Anyway, this is now less code and the TLA+ model is still correct and is slightly simpler.